### PR TITLE
feat/use-random-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hdkey": "^2.0.1",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
+    "random-js": "^2.1.0",
     "react": "^16.13.1",
     "react-animated-numbers": "^0.1.0",
     "react-dom": "^16.13.1",

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -203,7 +203,7 @@ function Dashboard(props: any) {
     const getAccountBalance = useCallback(() => {
         let currBalance = '0';
 
-        trackPromise(ZilliqaAccount.getBalance(currWalletAddress)
+        trackPromise(ZilliqaAccount.getBalanceWithNetwork(currWalletAddress, networkURL)
             .then((balance) => {
                 currBalance = balance;
             })
@@ -221,7 +221,7 @@ function Dashboard(props: any) {
                 }
 
             }), PromiseArea.PROMISE_GET_BALANCE);
-    }, [currWalletAddress]);
+    }, [currWalletAddress, networkURL]);
 
 
     // retrieve contract constants such as min stake
@@ -230,7 +230,7 @@ function Dashboard(props: any) {
         let minDelegStake = '0';
         let totalStakeAmt = '0';
 
-        ZilliqaAccount.getImplState(impl, "mindelegstake")
+        ZilliqaAccount.getImplStateExplorer(impl, networkURL, "mindelegstake")
             .then((contractState) => {
                 if (contractState === undefined || contractState === 'error') {
                     return null;
@@ -251,7 +251,7 @@ function Dashboard(props: any) {
                 setMinDelegStake(minDelegStake);
             });
         
-        ZilliqaAccount.getImplState(impl, 'totalstakeamount')
+        ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'totalstakeamount')
             .then((contractState) => {
                 if (contractState === undefined || contractState === 'error') {
                     return null;
@@ -271,7 +271,7 @@ function Dashboard(props: any) {
                 }
             });
 
-    }, [impl]);
+    }, [impl, networkURL]);
 
 
     /* fetch data for delegator stats panel */
@@ -284,7 +284,7 @@ function Dashboard(props: any) {
         
         const userBase16Address = fromBech32Address(currWalletAddress).toLowerCase();
 
-        trackPromise(ZilliqaAccount.getImplState(impl, 'deposit_amt_deleg')
+        trackPromise(ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'deposit_amt_deleg')
         .then(async (contractState) => {
             if (contractState === undefined || contractState === 'error') {
                 return null;
@@ -295,7 +295,7 @@ function Dashboard(props: any) {
             }
 
             // compute global APY
-            const totalStakeAmtState = await ZilliqaAccount.getImplState(impl, 'totalstakeamount');
+            const totalStakeAmtState = await ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'totalstakeamount');
             if (totalStakeAmtState['totalstakeamount']) {
                 let temp = new BigNumber(totalStakeAmtState['totalstakeamount']);
                 if (!temp.isEqualTo(0)) {
@@ -329,9 +329,9 @@ function Dashboard(props: any) {
             gzilRewards = totalZilRewardsBN;
 
             // get gzil balance
-            const gzilAddressState = await ZilliqaAccount.getImplState(impl, 'gziladdr');
+            const gzilAddressState = await ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'gziladdr');
             if (gzilAddressState.gziladdr) {
-                const gzilContractState = await ZilliqaAccount.getGzilContract(gzilAddressState['gziladdr']);
+                const gzilContractState = await ZilliqaAccount.getGzilContractWithNetwork(gzilAddressState['gziladdr'], networkURL);
                 if (gzilContractState.balances) {
                     const gzilBalanceMap = gzilContractState.balances;
                     if (gzilBalanceMap.hasOwnProperty(userBase16Address)) {
@@ -547,7 +547,7 @@ function Dashboard(props: any) {
     const getNodeOptionsList = useCallback(() => {
         let tempNodeOptions: NodeOptions[] = [];
 
-        ZilliqaAccount.getImplState(impl, "ssnlist")
+        ZilliqaAccount.getImplStateExplorer(impl, networkURL, "ssnlist")
             .then(async (contractState) => {
                 if (contractState === undefined || contractState === 'error') {
                     return null;
@@ -564,7 +564,7 @@ function Dashboard(props: any) {
 
                     
                     // get number of delegators
-                    const delegNumState = await ZilliqaAccount.getImplState(impl, 'ssn_deleg_amt');
+                    const delegNumState = await ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'ssn_deleg_amt');
                     let delegNum = '0';
 
                     if (delegNumState.hasOwnProperty('ssn_deleg_amt') &&
@@ -596,7 +596,7 @@ function Dashboard(props: any) {
                 setNodeOptions([...tempNodeOptions]);
             });
 
-    }, [impl]);
+    }, [impl, networkURL]);
 
 
     /* fetch data for operator stats panel */
@@ -611,7 +611,7 @@ function Dashboard(props: any) {
 
         const userBase16Address = fromBech32Address(currWalletAddress).toLowerCase();
 
-        trackPromise(ZilliqaAccount.getImplState(impl, 'ssnlist')
+        trackPromise(ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'ssnlist')
             .then(async (contractState) => {
                 if (contractState === undefined || contractState === 'error') {
                     return null;
@@ -624,7 +624,7 @@ function Dashboard(props: any) {
                 const ssnArgs = contractState['ssnlist'][userBase16Address]['arguments'];
 
                 // get number of delegators
-                const delegNumState = await ZilliqaAccount.getImplState(impl, 'ssn_deleg_amt');
+                const delegNumState = await ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'ssn_deleg_amt');
 
                 if (delegNumState.hasOwnProperty('ssn_deleg_amt') &&
                     userBase16Address in delegNumState['ssn_deleg_amt']) {
@@ -662,14 +662,14 @@ function Dashboard(props: any) {
                 }
 
             }), PromiseArea.PROMISE_GET_OPERATOR_STATS);
-    }, [impl, currWalletAddress]);
+    }, [impl, currWalletAddress, networkURL]);
 
 
     /* fetch data for ssn panel */
     const getSsnStats = useCallback(() => {
         let output: SsnStats[] = [];
 
-        trackPromise(ZilliqaAccount.getImplState(impl, 'ssnlist')
+        trackPromise(ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'ssnlist')
             .then(async (contractState) => {
                 if (contractState === undefined || contractState === 'error') {
                     return null;
@@ -686,7 +686,7 @@ function Dashboard(props: any) {
                     }
 
                     // get number of delegators
-                    const delegNumState = await ZilliqaAccount.getImplState(impl, 'ssn_deleg_amt');
+                    const delegNumState = await ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'ssn_deleg_amt');
 
                     if (delegNumState.hasOwnProperty('ssn_deleg_amt') &&
                         ssnAddress in delegNumState['ssn_deleg_amt']) {
@@ -721,7 +721,7 @@ function Dashboard(props: any) {
                     setSsnStats([...output]);
                 }
             }), PromiseArea.PROMISE_GET_SSN_STATS);
-    }, [impl]);
+    }, [impl, networkURL]);
 
 
     const toggleTheme = () => {

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -109,8 +109,9 @@ function Home(props: any) {
   const getContractConstants = useCallback(() => {
     let totalStakeAmt = '0';
     let impl = networks_config[selectedNetwork].impl;
+    let networkURL = networks_config[selectedNetwork].blockchain;
 
-    ZilliqaAccount.getImplState(impl, 'totalstakeamount')
+    ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'totalstakeamount')
     .then((contractState) => {
         if (contractState === undefined || contractState === 'error') {
             return null;
@@ -129,8 +130,9 @@ function Home(props: any) {
   const getSsnStats = useCallback(() => {
       let output: SsnStats[] = [];
       let impl = networks_config[selectedNetwork].impl;
+      let networkURL = networks_config[selectedNetwork].blockchain;
 
-      trackPromise(ZilliqaAccount.getImplState(impl, 'ssnlist')
+      trackPromise(ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'ssnlist')
           .then(async (contractState) => {
               if (contractState === undefined || contractState === 'error') {
                   return null;
@@ -147,7 +149,7 @@ function Home(props: any) {
                   }
 
                   // get number of delegators
-                  const delegNumState = await ZilliqaAccount.getImplState(impl, 'ssn_deleg_amt');
+                  const delegNumState = await ZilliqaAccount.getImplStateExplorer(impl, networkURL, 'ssn_deleg_amt');
 
                   if (delegNumState.hasOwnProperty('ssn_deleg_amt') &&
                       ssnAddress in delegNumState['ssn_deleg_amt']) {

--- a/src/components/landing-stats-table.tsx
+++ b/src/components/landing-stats-table.tsx
@@ -50,7 +50,7 @@ function LandingStatsTable(props: any) {
                 delegNum = Object.keys(contract.deposit_amt_deleg).length.toString();
 
                 // compute circulating supply
-                const totalCoinSupply = await ZilliqaAccount.getTotalCoinSupply();
+                const totalCoinSupply = await ZilliqaAccount.getTotalCoinSupplyWithNetwork(networkURL);
                 const totalStakeAmount = contract.totalstakeamount;
                 totalDeposits = totalStakeAmount.toString();
 
@@ -64,7 +64,7 @@ function LandingStatsTable(props: any) {
                 }
 
                 // compute total number of gzil
-                const gzilContract = await ZilliqaAccount.getGzilContract(contract.gziladdr);
+                const gzilContract = await ZilliqaAccount.getGzilContractWithNetwork(contract.gziladdr, networkURL);
                 if (gzilContract !== undefined) {
                     // gzil is 15 decimal places
                     gzil = gzilContract.total_supply;

--- a/src/util/random-api.ts
+++ b/src/util/random-api.ts
@@ -1,0 +1,53 @@
+/**
+ * fetch a random API from a pre-defined list
+ * used to minimize load on main API
+ */
+
+
+import { NetworkURL } from "./enum";
+
+const { Random, MersenneTwister19937 } = require("random-js");
+const randomJS = new Random(MersenneTwister19937.autoSeed());
+
+// Testnet
+const TESTNET_API_LIST = [
+    "http://18.133.61.123:4201",
+    "https://seed-dev-api.zillet.io",
+    "http://optimus-api-elb-267956463.us-west-2.elb.amazonaws.com"
+];
+
+
+// Mainnet
+const MAINNET_API_LIST = [
+    "https://ssn.zillacracy.com/api",
+    "https://zilliqa.atomicwallet.io/api",
+    "https://ssn-api-mainnet.viewblock.io",
+    "https://ssn-zilliqa.cex.io/api",
+    "https://ssn.zillet.io",
+    "https://zil-staking.ezil.me/api",
+    "https://stakingseed-api.seed.zilliqa.com",
+    "https://seed-zil.shardpool.io",
+    "https://zilliqa-api.staked.cloud",
+];
+
+// https://staking-zil.kucoin.com/api", CORS error
+// https://ssn-zilliqa.moonlet.network/api , CORS error
+
+
+// @todo: check api aliveness?
+export const getRandomAPI = (networkURL: string) => {
+    let api = "";
+    // determine from the network URL
+    // network URL should be api.zilliqa.com or dev-api.zilliqa.com
+    // if it is testnet or mainnet
+    if (networkURL === NetworkURL.MAINNET) {
+        const index = randomJS.integer(0, (MAINNET_API_LIST.length-1));
+        api = MAINNET_API_LIST[index];
+    } else {
+        // everything else is testnet
+        const index = randomJS.integer(0, (TESTNET_API_LIST.length-1));
+        api = TESTNET_API_LIST[index];
+    }
+    console.log("utilizing random api: %o", api);
+    return api;
+};

--- a/src/util/reward-calculator.ts
+++ b/src/util/reward-calculator.ts
@@ -1,3 +1,4 @@
+import { getRandomAPI } from "./random-api";
 
 const { RewardCalculator } = require('./calculator')
 
@@ -5,7 +6,7 @@ let rewardCalculator: typeof RewardCalculator;
 
 export const computeDelegRewards = async (impl: string, networkURL: string, ssn: string, delegator: string) => {
     if (!rewardCalculator) {
-        rewardCalculator = new RewardCalculator(networkURL, impl);
+        rewardCalculator = new RewardCalculator(getRandomAPI(networkURL), impl);
     }
 
     return rewardCalculator.get_rewards(ssn, delegator);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9210,6 +9210,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+random-js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/random-js/-/random-js-2.1.0.tgz#0c03238b0a4f701f7a4c7303036ade3083d8ee14"
+  integrity sha512-CRUyWmnzmZBA7RZSVGq0xMqmgCyPPxbiKNLFA5ud7KenojVX2s7Gv+V7eB52beKTPGxWRnVZ7D/tCIgYJJ8vNQ==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.0.6, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
- use random API from a pre-defined list to query contract information

## IMPORTANT
- no check for API aliveness, if the API fail, the user have to click refresh button in dashboard
- doesn't automatically switch API if one fail
- doesn't fallback to zilliqa's API if all APIs are down