### PR TITLE
fix: remove moonlet from api list

### DIFF
--- a/src/util/random-api.ts
+++ b/src/util/random-api.ts
@@ -20,7 +20,6 @@ const TESTNET_API_LIST = [
 // Mainnet
 const MAINNET_API_LIST = [
     "https://ssn.zillacracy.com/api",
-    "https://ssn-api-mainnet.viewblock.io",	
     "https://ssn-zilliqa.cex.io/api",
     "https://ssn.zillet.io",
     "https://zil-staking.ezil.me/api",
@@ -31,6 +30,7 @@ const MAINNET_API_LIST = [
 
 // https://ssn-zilliqa.moonlet.network/api , CORS error
 // https://zilliqa-api.staked.cloud, out-of-sync
+// "https://ssn-api-mainnet.viewblock.io", rate limit
 
 
 // @todo: check api aliveness?


### PR DESCRIPTION
Moonlet: CORS error
Viewblock: rate limit