### PR TITLE
fix/swap-form-wordings

### DIFF
--- a/src/components/contract-calls/swap-deleg.tsx
+++ b/src/components/contract-calls/swap-deleg.tsx
@@ -447,7 +447,6 @@ function SwapDelegModal(props: any) {
                 window.localStorage.setItem("show-swap-help", JSON.stringify(false));
             }
         }
-        console.log("swapp....");
     }, [])
 
     return (


### PR DESCRIPTION
- fix grammar on the swap dialog tutorials
- add the ability to show the tutorials when users click on the "Change Stake Ownership" for the first time