### PR TITLE
fix/ledger-error-custom-gas

### DIFF
--- a/src/zilliqa-signer.ts
+++ b/src/zilliqa-signer.ts
@@ -145,8 +145,8 @@ export class ZilSigner {
                 amount: `${txParams.amount}`,
                 code: txParams.code,
                 data: txParams.data,
-                gasPrice: `${txParams.gasPrice || gasPrice}`,
-                gasLimit: `${txParams.gasLimit || gasLimit}`,
+                gasPrice: new BN(txParams.gasPrice || gasPrice),
+                gasLimit: Long.fromNumber(Number(txParams.gasLimit || gasLimit)),
                 nonce: nonce,
                 pubKey: pubKey,
                 signature: "",
@@ -156,8 +156,8 @@ export class ZilSigner {
             const signedTx = {
                 ...txnParams,
                 amount: `${txParams.amount}`,
-                gasPrice: `${gasPrice}`,
-                gasLimit: `${gasLimit}`,
+                gasPrice: `${txParams.gasPrice || gasPrice}`,
+                gasLimit: `${txParams.gasLimit || gasLimit}`,
                 signature
             }
             console.log("signed tx: ", signedTx);


### PR DESCRIPTION
- Fixed an error for ledger signing when users try to set custom gas fees. 
  - The initial transaction is signed with the custom gas fees but it is wrongly reset to the default value before sending over to blockchain, causing a mismatch in the signature.
 - Fixed transaction: https://viewblock.io/zilliqa/tx/0x8d75a44b4395d3372b41594040f2be322e41f233d0f4a5c01a3d9040d1c1c0ba?network=testnet