### PR TITLE
change robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
In order for the testnet-stake.zilliqa.com  not to be parsed from SEO engines, as requested 